### PR TITLE
Added nose arguments to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,7 @@
 [nosetests]
-verbosity=1
-
-[coverage:report]
-show_missing = True
-
-[flake8]
-per-file-ignores =
-    */__init__.py: F401 E402
-
-[pylint.'MESSAGES CONTROL']
-disable=E1101
+verbosity=2
+with-spec=1
+spec-color=1
+with-coverage=1
+cover-erase=1
+cover-package=service


### PR DESCRIPTION
Configured nosetests in setup.cfg with verbosity, spec output, and coverage for the customer accounts microservice setup.

